### PR TITLE
update package name in examples...

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Also, if `loadDatabase` fails, all commands registered to the executor afterward
 
 ```javascript
 // Type 1: In-memory only datastore (no need to load the database)
-var Datastore = require('nedb')
+var Datastore = require('nedb-core')
   , db = new Datastore();
 
 
 // Type 2: Persistent datastore with manual loading
-var Datastore = require('nedb')
+var Datastore = require('nedb-core')
   , db = new Datastore({ filename: 'path/to/datafile' });
 db.loadDatabase(function (err) {    // Callback is optional
   // Now commands will be executed
@@ -73,14 +73,14 @@ db.loadDatabase(function (err) {    // Callback is optional
 
 
 // Type 3: Persistent datastore with automatic loading
-var Datastore = require('nedb')
+var Datastore = require('nedb-core')
   , db = new Datastore({ filename: 'path/to/datafile', autoload: true });
 // You can issue commands right away
 
 
 // Type 4: Persistent datastore for a Node Webkit app called 'nwtest'
 // For example on Linux, the datafile will be ~/.config/nwtest/nedb-data/something.db
-var Datastore = require('nedb')
+var Datastore = require('nedb-core')
   , path = require('path')
   , db = new Datastore({ filename: path.join(require('nw.gui').App.dataPath, 'something.db') });
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NeDB - The JavaScript Database   
+# NeDB - The JavaScript Database  
 [![Build Status](http://img.shields.io/travis/nedbhq/nedb-core.svg)](https://travis-ci.org/nedbhq/nedb-core)
 
 **Embedded persistent or in memory database for Node.js, nw.js, Electron and browsers, 100% JavaScript, no binary dependency**. API is a subset of MongoDB's and it's <a href="#speed">plenty fast</a>.


### PR DESCRIPTION
I speculate this is a fork of `nedb` you had to publish on your own in a different name.
so - the name in the docs is still `nedb`... :P